### PR TITLE
Feature: add testnet indicator

### DIFF
--- a/packages/ui/src/components/testnet-indicator.tsx
+++ b/packages/ui/src/components/testnet-indicator.tsx
@@ -1,0 +1,22 @@
+import envParsed from '@/envParsed';
+import cn from 'classnames';
+import { useAccount } from 'wagmi';
+
+interface TestnetIndicatorProps {
+  classNames?: string;
+}
+
+export function TestnetIndicator(props: TestnetIndicatorProps) {
+  const { isConnected } = useAccount();
+
+  // If user is connected to a testnet
+  if (envParsed().IS_TESTNET && isConnected) {
+    return (
+      <div className={cn('fixed bottom-5 right-5 bg-[#213147] text-white py-2 px-4 rounded-xl z-50', props.classNames)}>
+        You are on a testnet
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/packages/ui/src/routes/__root.tsx
+++ b/packages/ui/src/routes/__root.tsx
@@ -1,13 +1,15 @@
-import Topbar from "@/components/layout/topbar";
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import Topbar from '@/components/layout/topbar';
+import { TestnetIndicator } from '@/components/testnet-indicator';
+import { createRootRoute, Outlet } from '@tanstack/react-router';
 
 export const Route = createRootRoute({
   component: () => (
     <div className="min-h-screen overflow-y-auto bg-[url('@/assets/background.svg')] bg-cover">
       <Topbar />
-      <main className="py-8 px-4">
+      <main className='py-8 px-4'>
         <Outlet />
       </main>
+      <TestnetIndicator />
       {/* <TanStackRouterDevtools /> */}
     </div>
   ),


### PR DESCRIPTION
# Feature: add testnet indicator

Responds to [this task](https://wakeuplabs.atlassian.net/browse/AS-46?atlOrigin=eyJpIjoiZTM3NWYzOTAzYjYxNGNkMDg3ZmU2N2VmN2EyZTA4NmEiLCJwIjoiaiJ9)

## Description

This PR add a floating badge indicating wether the user is connected to a tesnet or not.

![image](https://github.com/user-attachments/assets/e51ff057-ce20-403c-8bc1-a05c08225509)
