### PR TITLE
update CI to allow domain without prefix

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -26,4 +26,4 @@ jobs:
         run: sam build
 
       - name: SAM Deploy
-        run: sam deploy --stack-name ${{ vars.STACK_NAME }} --parameter-overrides StackName='${{ vars.STACK_NAME }}' DomainName='${{vars.UI_DOMAIN}}' HostedZoneId='${{vars.AWS_HOSTED_ZONE_ID}}' CertificateId='${{vars.AWS_CERTIFICATE_ID}}'
+        run: sam deploy --stack-name ${{ vars.STACK_NAME }} --parameter-overrides StackName='${{ vars.STACK_NAME }}' UrlPrefix='${{ vars.URL_PREFIX }}'DomainName='${{vars.UI_DOMAIN}}' HostedZoneId='${{vars.AWS_HOSTED_ZONE_ID}}' CertificateId='${{vars.AWS_CERTIFICATE_ID}}'

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -50,4 +50,8 @@ jobs:
       - name: Deploy UI to s3
         working-directory: ./packages/ui
         run: |
-          aws s3 sync dist s3://${{ vars.STACK_NAME }}.${{vars.UI_DOMAIN}}/ --delete
+          if [ -n "${{ vars.URL_PREFIX }}" ]; then
+            aws s3 sync dist s3://${{ vars.URL_PREFIX }}.${{ vars.UI_DOMAIN }}/ --delete
+          else
+            aws s3 sync dist s3://${{ vars.UI_DOMAIN }}/ --delete
+          fi

--- a/packages/ui/template.yml
+++ b/packages/ui/template.yml
@@ -15,6 +15,9 @@ Parameters:
   CertificateId:
     Description: The ID of the existing certificate related to the domain name
     Type: String
+  UrlPrefix:
+    Description: The URL prefix to attach to the domain name
+    Type: String
 
 Resources:
   SecurityHeadersPolicy:
@@ -42,10 +45,17 @@ Resources:
             ModeBlock: true
             Override: true
 
+  Conditions:
+    HasUrlPrefix: !Not [!Equals [!Ref UrlPrefix, ""]]
+    
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "${StackName}.${DomainName}"
+      BucketName: 
+        !If
+          - HasUrlPrefix
+          - !Sub "${UrlPrefix}.${DomainName}"
+          - !Ref DomainName
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: index.html

--- a/template.yml
+++ b/template.yml
@@ -16,6 +16,10 @@ Parameters:
   CertificateId:
     Description: The ID of the existing certificate related to the domain name
     Type: String
+  UrlPrefix:
+    Description: The URL prefix to attach to the domain name
+    Type: String
+    Default: ""
 
 Resources:
   UI:
@@ -27,6 +31,7 @@ Resources:
         DomainName: !Ref DomainName
         HostedZoneId: !Ref HostedZoneId
         CertificateId: !Ref CertificateId
+        UrlPrefix: !Ref UrlPrefix
 
 Outputs:
   UIUrl:


### PR DESCRIPTION
Added prefix handling, now it doesn't rely on the stack name

New CI variables are already defined