### PR TITLE
add subdomain variable to ci

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,6 +1,12 @@
 name: infra
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "**/template.yml"
 
 jobs:
   Deploy:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -26,4 +26,4 @@ jobs:
         run: sam build
 
       - name: SAM Deploy
-        run: sam deploy --stack-name ${{ vars.STACK_NAME }} --parameter-overrides StackName='${{ vars.STACK_NAME }}' DomainName='${{vars.UI_DOMAIN}}' HostedZoneId='${{vars.AWS_HOSTED_ZONE_ID}}' CertificateId='${{vars.AWS_CERTIFICATE_ID}}'
+        run: sam deploy --stack-name ${{ vars.STACK_NAME }} --parameter-overrides StackName='${{ vars.STACK_NAME }}' DomainName='${{vars.UI_DOMAIN}}' Subdomain='${{vars.SUBDOMAIN}}' HostedZoneId='${{vars.AWS_HOSTED_ZONE_ID}}' CertificateId='${{vars.AWS_CERTIFICATE_ID}}'

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,12 +1,6 @@
 name: infra
 
-on:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - "**/template.yml"
+on: workflow_dispatch
 
 jobs:
   Deploy:

--- a/packages/ui/template.yml
+++ b/packages/ui/template.yml
@@ -9,6 +9,9 @@ Parameters:
   DomainName: 
     Description: The domain name of the existing Route 53 hosted zone
     Type: String
+  Subdomain:
+    Description: The subdomain name of the existing Route 53 hosted zone
+    Type: String
   HostedZoneId:
     Description: The ID of the existing Route 53 hosted zone
     Type: String
@@ -45,7 +48,7 @@ Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "${StackName}.${DomainName}"
+      BucketName: !Sub "${Subdomain}.${DomainName}"
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: index.html

--- a/template.yml
+++ b/template.yml
@@ -10,6 +10,9 @@ Parameters:
   DomainName:
     Description: The domain name of the existing Route 53 hosted zone, should match HostedZoneId
     Type: String
+  Subdomain:
+    Description: The subdomain name of the existing Route 53 hosted zone
+    Type: String
   HostedZoneId:
     Description: The ID of the existing Route 53 hosted zone, should match DomainName
     Type: String
@@ -25,6 +28,7 @@ Resources:
       Parameters:
         StackName: !Ref StackName
         DomainName: !Ref DomainName
+        Subdomain: !Ref Subdomain
         HostedZoneId: !Ref HostedZoneId
         CertificateId: !Ref CertificateId
 


### PR DESCRIPTION
Now the deployment subdomain is not tied to stack name.

Previous closed PR was about conditionally adding the subdomain, which is an unnecesary complexity

It has it's own variable on Github environment variables, which is already defined.

For now I disabled the infra workflow because some resources where modified manually and might get deleted with this update if the stackname is kept the same