### PR TITLE
Fix/wagmi reconnect loop

### DIFF
--- a/packages/ui/src/components/transaction/status-refactor.tsx
+++ b/packages/ui/src/components/transaction/status-refactor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Transaction } from "@/lib/transactions";
 import { useAlertContext } from "@/contexts/alert/alert-context";
 import useOnScreen from "@/hooks/use-on-screen";
@@ -46,7 +46,7 @@ export function TransactionStatus({ tx }: { tx: Transaction }) {
           <>
             <InitiateWithdrawal
               transaction={transaction}
-              childChain={childChain as Chain}
+              childChain={childChain}
             />
             <ConfirmWithdrawal
               transaction={transaction}
@@ -54,7 +54,7 @@ export function TransactionStatus({ tx }: { tx: Transaction }) {
               fetchingInboxTxTimestamp={fetchingInboxTxTimestamp}
               updateTx={updateTx}
               state={transactionState}
-              parentChain={parentChain as Chain}
+              parentChain={parentChain}
             />
             <ForceStep
               transaction={transaction}
@@ -63,7 +63,7 @@ export function TransactionStatus({ tx }: { tx: Transaction }) {
               fetchingClaimStatus={fetchingClaimStatus}
               fetchingL2ToL1Msg={fetchingL2ToL1Msg}
               state={transactionState}
-              parentChain={parentChain as Chain}
+              parentChain={parentChain}
             />
             <ClaimStep
               transaction={transaction}

--- a/packages/ui/src/components/transaction/steps/confirmWithdrawal.tsx
+++ b/packages/ui/src/components/transaction/steps/confirmWithdrawal.tsx
@@ -9,7 +9,7 @@ import { StatusStep } from "../status-step";
 import { useStepStatus } from "@/hooks/use-step-status";
 import CustomChainService from "@/services/custom-chain-service";
 import { useEffect, useState } from "react";
-import { Chain } from "wagmi/chains";
+import { CustomChain } from "@/types";
 
 export default function ConfirmWithdrawal({
   transaction,
@@ -24,7 +24,7 @@ export default function ConfirmWithdrawal({
   fetchingInboxTxTimestamp: boolean;
   updateTx: (tx: Transaction) => Promise<void>;
   state: TransactionState;
-  parentChain: Chain;
+  parentChain?: CustomChain;
 }) {
   const [parentTxUrl, setParentTxUrl] = useState("");
   const { signer, pushChildTxToParent } = useArbitrumBridge({
@@ -90,7 +90,7 @@ export default function ConfirmWithdrawal({
       running={isRunning}
       number={2}
       title="Confirm Withdraw"
-      description={`Send the ${parentChain.name} withdraw transaction through the delayed inbox`}
+      description={`Send the ${parentChain?.name} withdraw transaction through the delayed inbox`}
       className="pt-2 space-y-2 md:space-y-0 md:space-x-2 mb-4 flex items-start flex-col md:flex-row md:items-center"
     >
       {ACTIVE && (

--- a/packages/ui/src/components/transaction/steps/force.tsx
+++ b/packages/ui/src/components/transaction/steps/force.tsx
@@ -7,7 +7,7 @@ import { StatusStep } from "../status-step";
 import { useStepStatus } from "@/hooks/use-step-status";
 import { Step, TransactionState } from "@/constants";
 import { calculateRemainingHours } from "@/lib/helpers";
-import { Chain } from "wagmi/chains";
+import { CustomChain } from "@/types";
 
 function ForceIncludeButton({
   transaction,
@@ -54,7 +54,7 @@ export default function ForceStep({
   fetchingL2ToL1Msg: boolean;
   triggered: boolean;
   state: TransactionState;
-  parentChain: Chain;
+  parentChain?: CustomChain;
 }) {
   const { signer, forceInclude } = useArbitrumBridge({
     parentChainId: transaction.parentChainId,
@@ -87,7 +87,7 @@ export default function ForceStep({
       running={isLoading}
       number={3}
       title="Force transaction"
-      description={`If after 24 hours your ${parentChain.name} transaction hasn't been mined, you can push it forward manually with some extra fee in ${parentChain.nativeCurrency.symbol}`}
+      description={`If after 24 hours your ${parentChain?.name} transaction hasn't been mined, you can push it forward manually with some extra fee in ${parentChain?.nativeCurrency.symbol}`}
       className="flex flex-col items-start pt-2 space-y-2 md:space-y-0 md:space-x-2 mb-4 md:flex-row md:items-center"
     >
       {state === TransactionState.FORCEABLE ? (

--- a/packages/ui/src/components/transaction/steps/initiateWithdrawal.tsx
+++ b/packages/ui/src/components/transaction/steps/initiateWithdrawal.tsx
@@ -3,14 +3,14 @@ import { StatusStep } from "../status-step";
 import { Transaction } from "@/lib/transactions";
 import CustomChainService from "@/services/custom-chain-service";
 import { useEffect, useState } from "react";
-import { Chain } from "wagmi/chains";
+import { CustomChain } from "@/types";
 
 export default function InitiateWithdrawal({
   transaction,
   childChain,
 }: {
   transaction: Transaction;
-  childChain: Chain;
+  childChain?: CustomChain;
 }) {
   const [l2TxUrl, setL2TxUrl] = useState("");
   useEffect(() => {
@@ -25,7 +25,7 @@ export default function InitiateWithdrawal({
       done
       number={1}
       title="Initiate Withdraw"
-      description={`Your withdraw transaction in ${childChain.name}`}
+      description={`Your withdraw transaction in ${childChain?.name}`}
       className="pt-2 md:flex md:space-x-4 mb-4"
     >
       <a
@@ -34,7 +34,7 @@ export default function InitiateWithdrawal({
         className="link text-sm flex space-x-1 items-center"
         rel="noreferrer"
       >
-        <span>{childChain.name} tx </span>
+        <span>{childChain?.name} tx </span>
         <ArrowUpRight className="h-3 w-3" />
       </a>
     </StatusStep>

--- a/packages/ui/src/contexts/chains-context.tsx
+++ b/packages/ui/src/contexts/chains-context.tsx
@@ -7,6 +7,7 @@ import {
   registerCustomArbitrumNetwork,
 } from "@arbitrum/sdk";
 import { arbitrum, arbitrumSepolia } from "viem/chains";
+import { FILTERS } from "@/constants";
 
 type ChainsContextType = {
   chains: CustomChain[];
@@ -23,16 +24,17 @@ export function ChainsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const getAllChains = async () => {
       // All chains must be registered to wagmi & to the arb sdk
-      const allChains = await CustomChainService.getAllChains();
-
-      // So we de-duplicate since we use the same table for every user
-      const dedupedChains = allChains.filter(
-        (obj, index, self) =>
-          self.findIndex((o) => o.chainId === obj.chainId) === index
+      const lastAddress = localStorage.getItem("last-wallet-address");
+      const userChains = await CustomChainService.getUserChains(
+        (lastAddress ?? "0x") as `0x${string}`,
+        "",
+        FILTERS.ALL
       );
+
       const arbNetworks = getArbitrumNetworks();
-      dedupedChains
+      userChains
         .filter((x) => !arbNetworks.some((y) => y.chainId === x.chainId))
+        .filter((x) => x.isOrbit)
         .forEach((chain) => {
           if (
             chain.chainId !== arbitrumSepolia.id &&
@@ -48,7 +50,7 @@ export function ChainsProvider({ children }: { children: ReactNode }) {
           }
         });
 
-      setChains(dedupedChains as unknown as CustomChain[]);
+      setChains(userChains as unknown as CustomChain[]);
     };
     getAllChains();
   }, []);

--- a/packages/ui/src/contexts/selected-chain.tsx
+++ b/packages/ui/src/contexts/selected-chain.tsx
@@ -1,9 +1,6 @@
 import { createContext, useState, ReactNode, useEffect } from "react";
 import { CustomChain } from "@/types";
-import {
-  defaultCustomChild,
-  defaultCustomMainnet,
-} from "@/lib/wagmi-config";
+import { defaultCustomChild, defaultCustomMainnet } from "@/lib/wagmi-config";
 import {
   getArbitrumNetworks,
   registerCustomArbitrumNetwork,

--- a/packages/ui/src/contexts/selected-chain.tsx
+++ b/packages/ui/src/contexts/selected-chain.tsx
@@ -1,10 +1,6 @@
 import { createContext, useState, ReactNode, useEffect } from "react";
 import { CustomChain } from "@/types";
 import {
-  customArbitrum,
-  customArbitrumSepolia,
-  customMainnet,
-  customSepolia,
   defaultCustomChild,
   defaultCustomMainnet,
 } from "@/lib/wagmi-config";
@@ -42,39 +38,28 @@ export function SelectedChainProvider({ children }: { children: ReactNode }) {
   const [customChains, setCustomChains] = useState<CustomChain[]>([]);
   const { chains } = useChains();
 
-  const initializeCustomChains = async (address: Address) => {
-    const userChains = await CustomChainService.getUserChains(
-      address,
-      "",
-      FILTERS.ALL
-    );
-    if (!userChains.some((x) => x.chainId === customArbitrum.chainId)) {
-      const defaultChain = { ...customArbitrum, user: address };
-      userChains.push({ ...defaultChain, user: address } as any);
-      await CustomChainService.addChain(defaultChain);
-    }
-    if (!userChains.some((x) => x.chainId === customMainnet.chainId)) {
-      const defaultChain = { ...customMainnet, user: address };
-      await CustomChainService.addChain(defaultChain);
-    }
-    if (!userChains.some((x) => x.chainId === customSepolia.chainId)) {
-      const defaultChain = { ...customSepolia, user: address };
-      await CustomChainService.addChain(defaultChain);
-    }
-    if (!userChains.some((x) => x.chainId === customArbitrumSepolia.chainId)) {
-      const defaultChain = { ...customArbitrumSepolia, user: address };
-      userChains.push({ ...defaultChain, user: address } as any);
-      await CustomChainService.addChain(defaultChain);
-    }
-
-    if (!userChains.some((x) => x.chainId === selectedChain.chainId))
-      setSelectedChain(defaultCustomChild);
-
-    setCustomChains(userChains as CustomChain[]);
-  };
-
   useEffect(() => {
     if (!address) return;
+    const initializeCustomChains = async (address: Address) => {
+      const userChains = await CustomChainService.getUserChains(
+        address,
+        "",
+        FILTERS.ALL
+      );
+
+      if (!userChains.some((x) => x.chainId === selectedChain.chainId))
+        setSelectedChain(defaultCustomChild);
+
+      setCustomChains(userChains as CustomChain[]);
+    };
+
+    const lastAddress = localStorage.getItem("last-wallet-address");
+
+    if (address !== lastAddress) {
+      localStorage.setItem("last-wallet-address", address);
+      window.location.reload();
+    }
+
     initializeCustomChains(address);
   }, [address]);
 

--- a/packages/ui/src/contexts/web3-client-context.tsx
+++ b/packages/ui/src/contexts/web3-client-context.tsx
@@ -28,7 +28,7 @@ export const Web3ClientProvider: React.FC<Web3ClientProviderProps> = ({
         ...selectedParentChain,
         id: selectedParentChain.chainId,
       }),
-    [selectedParentChain?.chainId]
+    [selectedParentChain]
   );
 
   const childChainSelected = useMemo(
@@ -37,7 +37,7 @@ export const Web3ClientProvider: React.FC<Web3ClientProviderProps> = ({
         ...selectedChain,
         id: selectedChain.chainId,
       }),
-    [selectedChain?.chainId]
+    [selectedChain]
   );
   const publicParentClient = useMemo(
     () =>
@@ -45,7 +45,7 @@ export const Web3ClientProvider: React.FC<Web3ClientProviderProps> = ({
         chain: parentChainSelected,
         transport: http(parentChainSelected.rpcUrls.default.http[0]),
       }),
-    [parentChainSelected.chainId]
+    [parentChainSelected]
   );
 
   const publicChildClient = useMemo(
@@ -54,7 +54,7 @@ export const Web3ClientProvider: React.FC<Web3ClientProviderProps> = ({
         chain: childChainSelected,
         transport: http(childChainSelected.rpcUrls.default.http[0]),
       }),
-    [childChainSelected.chainId]
+    [childChainSelected]
   );
 
   const parentProvider = useMemo(
@@ -62,14 +62,14 @@ export const Web3ClientProvider: React.FC<Web3ClientProviderProps> = ({
       new ethers.providers.JsonRpcProvider(
         parentChainSelected.rpcUrls.default.http[0]
       ),
-    [parentChainSelected.chainId]
+    [parentChainSelected]
   );
   const childProvider = useMemo(
     () =>
       new ethers.providers.JsonRpcProvider(
         childChainSelected.rpcUrls.default.http[0]
       ),
-    [childChainSelected.chainId]
+    [childChainSelected]
   );
 
   const values = {

--- a/packages/ui/src/hooks/use-arbitrum-bridge.tsx
+++ b/packages/ui/src/hooks/use-arbitrum-bridge.tsx
@@ -136,11 +136,15 @@ export default function useArbitrumBridge(props: {
     childProvider: ethers.providers.JsonRpcProvider,
     parentSigner: ethers.providers.JsonRpcSigner
   ) {
+    console.log("getting l2tol1msg");
+    console.log("l2TxnHash: ", l2TxnHash);
     if (!l2TxnHash.startsWith("0x") || l2TxnHash.trim().length != 66)
       throw new Error(`Hmm, ${l2TxnHash} doesn't look like a txn hash...`);
-
+    
+    console.log("childProvider: ", childProvider);
     // First, let's find the Arbitrum txn from the txn hash provided
     const receipt = await childProvider.getTransactionReceipt(l2TxnHash);
+    console.log("receipt: ", receipt);
     if (receipt === null) return receipt;
 
     const l2Receipt = new ChildTransactionReceipt(receipt);
@@ -155,6 +159,7 @@ export default function useArbitrumBridge(props: {
     childProvider: ethers.providers.JsonRpcProvider,
     l2ToL1Msg: ChildToParentMessageWriter
   ): Promise<ClaimStatus> {
+    console.log("getting claim status");
     if (!l2ToL1Msg) {
       throw new Error(
         "Provide an L2 transaction that sends an L2 to L1 message or the message itself"

--- a/packages/ui/src/hooks/use-arbitrum-bridge.tsx
+++ b/packages/ui/src/hooks/use-arbitrum-bridge.tsx
@@ -140,7 +140,7 @@ export default function useArbitrumBridge(props: {
     console.log("l2TxnHash: ", l2TxnHash);
     if (!l2TxnHash.startsWith("0x") || l2TxnHash.trim().length != 66)
       throw new Error(`Hmm, ${l2TxnHash} doesn't look like a txn hash...`);
-    
+
     console.log("childProvider: ", childProvider);
     // First, let's find the Arbitrum txn from the txn hash provided
     const receipt = await childProvider.getTransactionReceipt(l2TxnHash);

--- a/packages/ui/src/lib/wagmi-config.ts
+++ b/packages/ui/src/lib/wagmi-config.ts
@@ -45,7 +45,7 @@ export const customSepolia: CustomChain = {
     default: {
       http: ["https://ethereum-sepolia-rpc.publicnode.com"],
     },
-  }
+  },
 };
 
 export const defaultCustomMainnet = envParsed().IS_TESTNET
@@ -72,7 +72,7 @@ export const customArbitrum: CustomChain = {
     default: {
       http: [arbitrum.rpcUrls.default.http[0]],
     },
-  }
+  },
 };
 const arbitrumSepoliaNetwork = getArbitrumNetwork(arbitrumSepolia.id);
 export const customArbitrumSepolia: CustomChain = {
@@ -94,7 +94,7 @@ export const customArbitrumSepolia: CustomChain = {
     default: {
       http: [arbitrumSepolia.rpcUrls.default.http[0]],
     },
-  }
+  },
 };
 
 export const defaultCustomChild = envParsed().IS_TESTNET

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -97,7 +97,7 @@ export const api = {
         chainId: parseInt(chain.chainId),
       }));
     },
-    getByChainId: async (chainId: number) => {
+    getByChainId: async (chainId: number): Promise<CustomChain> => {
       const res = await client.api.chains.chains.get[":id"].$get({
         param: { id: chainId.toString() },
       });
@@ -111,7 +111,7 @@ export const api = {
       return {
         ...data,
         chainId: parseInt(data.chainId)
-      };
+      } as CustomChain;
     },
     create: async (chain: CustomChain) => {
       const res = await client.api.chains.chains.create.$post({

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -110,7 +110,7 @@ export const api = {
 
       return {
         ...data,
-        chainId: parseInt(data.chainId)
+        chainId: parseInt(data.chainId),
       } as CustomChain;
     },
     create: async (chain: CustomChain) => {
@@ -139,7 +139,7 @@ export const api = {
           userAddress: chain.user as string,
           chainId: chain.chainId.toString(),
           logoURI: chain.logoURI ?? null,
-          tokenBridge: chain.tokenBridge
+          tokenBridge: chain.tokenBridge,
         },
       });
 

--- a/packages/ui/src/services/custom-chain-service.tsx
+++ b/packages/ui/src/services/custom-chain-service.tsx
@@ -109,8 +109,8 @@ export default class CustomChainService {
   ) => {
     const promises = [api.chains.getAllPublic()];
     if (userAddress !== "0x")
-      promises.push(api.chains.getAllUserChains(userAddress))
-    
+      promises.push(api.chains.getAllUserChains(userAddress));
+
     const [publicChains, userChains] = await Promise.all(promises);
 
     return [...publicChains, ...userChains].filter((chain) =>

--- a/packages/ui/src/services/custom-chain-service.tsx
+++ b/packages/ui/src/services/custom-chain-service.tsx
@@ -107,10 +107,11 @@ export default class CustomChainService {
     filter: FILTERS,
     testnetFilter?: NetworkFilter
   ) => {
-    const [publicChains, userChains] = await Promise.all([
-      api.chains.getAllPublic(),
-      api.chains.getAllUserChains(userAddress),
-    ]);
+    const promises = [api.chains.getAllPublic()];
+    if (userAddress !== "0x")
+      promises.push(api.chains.getAllUserChains(userAddress))
+    
+    const [publicChains, userChains] = await Promise.all(promises);
 
     return [...publicChains, ...userChains].filter((chain) =>
       CustomChainService.filterChain(


### PR DESCRIPTION
## Tickets
[AFIV2-73](https://wakeuplabs.atlassian.net/browse/AFIV2-73)
[AFIV2-83](https://wakeuplabs.atlassian.net/browse/AFIV2-83)

## Description
User custom chains weren't being loaded dynamically on wagmi/arbitrum sdk

## Solution
Set last wagmi address on localstorage and reload page on change.
This reloads the page, hence, the wagmi config correctly since user address is now available before wagmi spinup

[AFIV2-73]: https://wakeuplabs.atlassian.net/browse/AFIV2-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AFIV2-83]: https://wakeuplabs.atlassian.net/browse/AFIV2-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ