### PR TITLE
Fix/check force include activity list

### DIFF
--- a/packages/ui/src/components/transaction/status-refactor.tsx
+++ b/packages/ui/src/components/transaction/status-refactor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Transaction } from "@/lib/transactions";
 import { useAlertContext } from "@/contexts/alert/alert-context";
 import useOnScreen from "@/hooks/use-on-screen";
@@ -27,7 +27,7 @@ export function TransactionStatus({ tx }: { tx: Transaction }) {
     fetchingL2ToL1Msg,
     l2ToL1Msg,
     canClaim,
-  } = useTransaction({ tx: tx, enabled: triggered });
+  } = useTransaction({ tx: tx, enabled: triggered, childChain, parentChain });
 
   const transactionState = useTransactionStatus(transaction);
   useEffect(() => {
@@ -76,6 +76,7 @@ export function TransactionStatus({ tx }: { tx: Transaction }) {
               fetchingL2ToL1Msg={fetchingL2ToL1Msg}
               canClaim={canClaim}
               parentChain={parentChain as Chain}
+              childChain={childChain}
             />
           </>
         )}

--- a/packages/ui/src/components/transaction/status.tsx
+++ b/packages/ui/src/components/transaction/status.tsx
@@ -43,8 +43,8 @@ export function TransactionStatus(props: {
     ? calculateRemainingHours(transaction.delayedInboxTimestamp)
     : undefined;
   const { setError } = useAlertContext();
-    const { provider: childProvider } = useWeb3Client(childChain);
-    const { client: parentClient } = useWeb3Client(parentChain);
+  const { provider: childProvider } = useWeb3Client(childChain);
+  const { client: parentClient } = useWeb3Client(parentChain);
 
   const forceIncludeTx = useMutation({
     mutationFn: forceInclude,
@@ -63,7 +63,8 @@ export function TransactionStatus(props: {
 
   const { data: l2ToL1Msg, isFetching: fetchingL2ToL1Msg } = useQuery({
     queryKey: ["l2ToL1Msg", transaction.bridgeHash],
-    queryFn: () => getL2toL1Msg(transaction.bridgeHash, childProvider!, signer!),
+    queryFn: () =>
+      getL2toL1Msg(transaction.bridgeHash, childProvider!, signer!),
     enabled:
       triggered &&
       !!signer &&

--- a/packages/ui/src/components/transaction/status.tsx
+++ b/packages/ui/src/components/transaction/status.tsx
@@ -1,5 +1,4 @@
 import { useAlertContext } from "@/contexts/alert/alert-context";
-import { useWeb3ClientContext } from "@/contexts/web3-client-context";
 import useArbitrumBridge, { ClaimStatus } from "@/hooks/use-arbitrum-bridge";
 import useOnScreen from "@/hooks/use-on-screen";
 import { Transaction, TransactionsStorageService } from "@/lib/transactions";
@@ -15,6 +14,7 @@ import { StatusStep } from "./status-step";
 import { LEARN_MORE_URI } from "@/constants";
 import { Countdown } from "./countdown";
 import { useGetTransactionChains } from "@/hooks/queries/useGetTransactionChains";
+import { useWeb3Client } from "@/contexts/web3-client-context";
 
 //TODO: refactor this code : make it more readable and clean
 
@@ -37,13 +37,14 @@ export function TransactionStatus(props: {
   const [transaction, setTransaction] = useState<Transaction>(props.tx);
   const ref = useRef<HTMLDivElement>(null);
   const isVisible = useOnScreen(ref);
-  const { publicParentClient, childProvider } = useWeb3ClientContext();
   const { parentChain, childChain } = useGetTransactionChains(props.tx);
   const [triggered, setTriggered] = useState(false);
   const remainingHours = transaction.delayedInboxTimestamp
     ? calculateRemainingHours(transaction.delayedInboxTimestamp)
     : undefined;
   const { setError } = useAlertContext();
+    const { provider: childProvider } = useWeb3Client(childChain);
+    const { client: parentClient } = useWeb3Client(parentChain);
 
   const forceIncludeTx = useMutation({
     mutationFn: forceInclude,
@@ -62,10 +63,11 @@ export function TransactionStatus(props: {
 
   const { data: l2ToL1Msg, isFetching: fetchingL2ToL1Msg } = useQuery({
     queryKey: ["l2ToL1Msg", transaction.bridgeHash],
-    queryFn: () => getL2toL1Msg(transaction.bridgeHash, childProvider, signer!),
+    queryFn: () => getL2toL1Msg(transaction.bridgeHash, childProvider!, signer!),
     enabled:
       triggered &&
       !!signer &&
+      !!childProvider &&
       !!transaction.delayedInboxTimestamp &&
       transaction.claimStatus !== ClaimStatus.CLAIMED,
     staleTime: Infinity,
@@ -73,7 +75,7 @@ export function TransactionStatus(props: {
 
   const { data: claimStatusData, isFetching: fetchingClaimStatus } = useQuery({
     queryKey: ["claimStatus", transaction.bridgeHash],
-    queryFn: () => getClaimStatus(childProvider, l2ToL1Msg!),
+    queryFn: () => getClaimStatus(childProvider!, l2ToL1Msg!),
     enabled: !!l2ToL1Msg && !!childProvider && !!transaction.bridgeHash,
     staleTime: 60000,
     refetchOnMount: false,
@@ -96,9 +98,10 @@ export function TransactionStatus(props: {
   } = useQuery({
     queryKey: ["delayedInboxTimestamp", transaction.delayedInboxHash],
     queryFn: () =>
-      getTimestampFromTxHash(transaction.delayedInboxHash!, publicParentClient),
+      getTimestampFromTxHash(transaction.delayedInboxHash!, parentClient!),
     enabled:
       triggered &&
+      !!parentClient &&
       transaction.delayedInboxHash !== undefined &&
       !transaction.delayedInboxTimestamp,
   });
@@ -151,7 +154,7 @@ export function TransactionStatus(props: {
   }
 
   function onClaim() {
-    if (!signer) return;
+    if (!signer || !childProvider) return;
 
     claimFundsTx.mutate(
       {

--- a/packages/ui/src/components/transaction/steps/claim.tsx
+++ b/packages/ui/src/components/transaction/steps/claim.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import { useMutation } from "@tanstack/react-query";
 import { ChildToParentMessageWriter } from "@arbitrum/sdk";
-import { useWeb3ClientContext } from "@/contexts/web3-client-context";
 import useArbitrumBridge, { ClaimStatus } from "@/hooks/use-arbitrum-bridge";
 import { Transaction } from "@/lib/transactions";
 import { StatusStep } from "../status-step";
@@ -9,6 +8,8 @@ import { Countdown } from "../countdown";
 import { useStepStatus } from "@/hooks/use-step-status";
 import { Step, TransactionState } from "@/constants";
 import { Chain } from "wagmi/chains";
+import { CustomChain } from "@/types";
+import { useWeb3Client } from "@/contexts/web3-client-context";
 
 export default function ClaimStep({
   transaction,
@@ -20,6 +21,7 @@ export default function ClaimStep({
   state,
   canClaim,
   parentChain,
+  childChain,
 }: {
   transaction: Transaction;
   onError: (error: Error) => void;
@@ -31,12 +33,13 @@ export default function ClaimStep({
   fetchingL2ToL1Msg: boolean;
   canClaim: boolean;
   parentChain: Chain;
+  childChain?: CustomChain;
 }) {
   const { signer, claimFunds } = useArbitrumBridge({
     parentChainId: transaction.parentChainId,
     childChainId: transaction.childChainId,
   });
-  const { childProvider } = useWeb3ClientContext();
+  const { provider: childProvider } = useWeb3Client(childChain);
   const { ACTIVE, DONE } = useStepStatus(Step.CLAIM, state);
 
   const claimFundsTx = useMutation({
@@ -50,7 +53,7 @@ export default function ClaimStep({
     !fetchingQueries;
 
   function onClaim() {
-    if (!signer) return;
+    if (!signer || !childProvider) return;
 
     claimFundsTx.mutate(
       {

--- a/packages/ui/src/components/transaction/useGetTx.tsx
+++ b/packages/ui/src/components/transaction/useGetTx.tsx
@@ -1,42 +1,52 @@
-import { useWeb3ClientContext } from "@/contexts/web3-client-context";
+import { useWeb3Client } from "@/contexts/web3-client-context";
 import useArbitrumBridge, { ClaimStatus } from "@/hooks/use-arbitrum-bridge";
 import { Transaction, TransactionsStorageService } from "@/lib/transactions";
 import { getTimestampFromTxHash } from "@/lib/tx-actions";
+import { CustomChain } from "@/types";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 export const useTransaction = ({
   tx,
   enabled,
+  childChain,
+  parentChain,
 }: {
   tx: Transaction;
   enabled: boolean;
+  childChain?: CustomChain;
+  parentChain?: CustomChain;
 }) => {
   const [transaction, setTransaction] = useState<Transaction>(tx);
-  const { publicParentClient, childProvider } = useWeb3ClientContext();
   const { signer, getClaimStatus, getL2toL1Msg } = useArbitrumBridge({
     parentChainId: transaction.parentChainId,
     childChainId: transaction.childChainId,
   });
+  const { provider: childProvider } = useWeb3Client(childChain);
+  const { client: parentClient } = useWeb3Client(parentChain);
+
   const {
     data: delayedInboxTxTimestamp,
     isFetching: fetchingInboxTxTimestamp,
   } = useQuery({
     queryKey: ["delayedInboxTimestamp", transaction.delayedInboxHash],
     queryFn: () =>
-      getTimestampFromTxHash(transaction.delayedInboxHash!, publicParentClient),
+      getTimestampFromTxHash(transaction.delayedInboxHash!, parentClient!),
     enabled:
       enabled &&
+      !!parentClient &&
       transaction.delayedInboxHash !== undefined &&
       !transaction.delayedInboxTimestamp,
   });
 
   const { data: l2ToL1Msg, isFetching: fetchingL2ToL1Msg } = useQuery({
     queryKey: ["l2ToL1Msg", transaction.bridgeHash],
-    queryFn: () => getL2toL1Msg(transaction.bridgeHash, childProvider, signer!),
+    queryFn: () =>
+      getL2toL1Msg(transaction.bridgeHash, childProvider!, signer!),
     enabled:
       enabled &&
       !!signer &&
+      !!childProvider &&
       !!transaction.delayedInboxTimestamp &&
       transaction.claimStatus !== ClaimStatus.CLAIMED,
     staleTime: Infinity,
@@ -44,7 +54,7 @@ export const useTransaction = ({
 
   const { data: claimStatusData, isFetching: fetchingClaimStatus } = useQuery({
     queryKey: ["claimStatus", transaction.bridgeHash],
-    queryFn: () => getClaimStatus(childProvider, l2ToL1Msg!),
+    queryFn: () => getClaimStatus(childProvider!, l2ToL1Msg!),
     enabled: !!l2ToL1Msg && !!childProvider && !!transaction.bridgeHash,
     staleTime: 60000,
     refetchOnMount: false,

--- a/packages/ui/src/contexts/web3-client-context.tsx
+++ b/packages/ui/src/contexts/web3-client-context.tsx
@@ -1,97 +1,49 @@
-import { useSelectedChain } from "@/hooks/use-selected-chain";
+// src/contexts/Web3ClientContext.tsx
+import React, { createContext, useContext, useRef } from "react";
+import { CustomChain } from "@/types";
+import { defineChain, createPublicClient, PublicClient, http } from "viem";
 import { ethers } from "ethers";
-import React, { createContext, useContext, useMemo } from "react";
-import { createPublicClient, defineChain, http, PublicClient } from "viem";
 
-type Web3ClientContextValue = {
-  publicParentClient: PublicClient;
-  publicChildClient: PublicClient;
-  parentProvider: ethers.providers.JsonRpcProvider;
-  childProvider: ethers.providers.JsonRpcProvider;
+type ClientPair = {
+  client: PublicClient;
+  provider: ethers.providers.JsonRpcProvider;
 };
 
-const Web3ClientContext = createContext<Web3ClientContextValue | undefined>(
-  undefined
-);
+type Web3ClientContextValue = {
+  getClient: (chain: CustomChain) => ClientPair;
+};
 
-interface Web3ClientProviderProps {
-  children: React.ReactNode;
-}
+const Web3ClientContext = createContext<Web3ClientContextValue | undefined>(undefined);
 
-export const Web3ClientProvider: React.FC<Web3ClientProviderProps> = ({
-  children,
-}) => {
-  const { selectedChain, selectedParentChain } = useSelectedChain();
-  const parentChainSelected = useMemo(
-    () =>
-      defineChain({
-        ...selectedParentChain,
-        id: selectedParentChain.chainId,
-      }),
-    [selectedParentChain]
-  );
+export function Web3ClientProvider({ children }: { children: React.ReactNode }) {
+  // cacheRef.current[chainId] = { client, provider }
+  const cacheRef = useRef<Record<number, ClientPair>>({});
 
-  const childChainSelected = useMemo(
-    () =>
-      defineChain({
-        ...selectedChain,
-        id: selectedChain.chainId,
-      }),
-    [selectedChain]
-  );
-  const publicParentClient = useMemo(
-    () =>
-      createPublicClient({
-        chain: parentChainSelected,
-        transport: http(parentChainSelected.rpcUrls.default.http[0]),
-      }),
-    [parentChainSelected]
-  );
-
-  const publicChildClient = useMemo(
-    () =>
-      createPublicClient({
-        chain: childChainSelected,
-        transport: http(childChainSelected.rpcUrls.default.http[0]),
-      }),
-    [childChainSelected]
-  );
-
-  const parentProvider = useMemo(
-    () =>
-      new ethers.providers.JsonRpcProvider(
-        parentChainSelected.rpcUrls.default.http[0]
-      ),
-    [parentChainSelected]
-  );
-  const childProvider = useMemo(
-    () =>
-      new ethers.providers.JsonRpcProvider(
-        childChainSelected.rpcUrls.default.http[0]
-      ),
-    [childChainSelected]
-  );
-
-  const values = {
-    publicParentClient,
-    publicChildClient,
-    parentProvider,
-    childProvider,
+  const getClient = (chain: CustomChain): ClientPair => {
+    const { chainId, rpcUrls } = chain;
+    if (!cacheRef.current[chainId]) {
+      const viemChain = defineChain({ ...chain, id: chainId,  });
+      const client = createPublicClient({
+        chain: viemChain,
+        transport: http(rpcUrls.default.http[0]),
+      });
+      const provider = new ethers.providers.JsonRpcProvider(rpcUrls.default.http[0]);
+      cacheRef.current[chainId] = { client, provider };
+    }
+    return cacheRef.current[chainId];
   };
 
   return (
-    <Web3ClientContext.Provider value={values}>
+    <Web3ClientContext.Provider value={{ getClient }}>
       {children}
     </Web3ClientContext.Provider>
   );
-};
+}
 
-export const useWeb3ClientContext = (): Web3ClientContextValue => {
-  const context = useContext(Web3ClientContext);
-
-  if (!context) {
-    throw new Error("Web3ClientContext failed to initialize");
+export function useWeb3Client(chain?: CustomChain) {
+  const ctx = useContext(Web3ClientContext);
+  if (!ctx) {
+    throw new Error("`useWeb3Client` must be used within a `<Web3ClientProvider>`");
   }
-
-  return context;
-};
+  return chain ? ctx.getClient(chain) : { client: undefined, provider: undefined };
+}

--- a/packages/ui/src/contexts/web3-client-context.tsx
+++ b/packages/ui/src/contexts/web3-client-context.tsx
@@ -13,21 +13,29 @@ type Web3ClientContextValue = {
   getClient: (chain: CustomChain) => ClientPair;
 };
 
-const Web3ClientContext = createContext<Web3ClientContextValue | undefined>(undefined);
+const Web3ClientContext = createContext<Web3ClientContextValue | undefined>(
+  undefined
+);
 
-export function Web3ClientProvider({ children }: { children: React.ReactNode }) {
+export function Web3ClientProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   // cacheRef.current[chainId] = { client, provider }
   const cacheRef = useRef<Record<number, ClientPair>>({});
 
   const getClient = (chain: CustomChain): ClientPair => {
     const { chainId, rpcUrls } = chain;
     if (!cacheRef.current[chainId]) {
-      const viemChain = defineChain({ ...chain, id: chainId,  });
+      const viemChain = defineChain({ ...chain, id: chainId });
       const client = createPublicClient({
         chain: viemChain,
         transport: http(rpcUrls.default.http[0]),
       });
-      const provider = new ethers.providers.JsonRpcProvider(rpcUrls.default.http[0]);
+      const provider = new ethers.providers.JsonRpcProvider(
+        rpcUrls.default.http[0]
+      );
       cacheRef.current[chainId] = { client, provider };
     }
     return cacheRef.current[chainId];
@@ -43,7 +51,11 @@ export function Web3ClientProvider({ children }: { children: React.ReactNode }) 
 export function useWeb3Client(chain?: CustomChain) {
   const ctx = useContext(Web3ClientContext);
   if (!ctx) {
-    throw new Error("`useWeb3Client` must be used within a `<Web3ClientProvider>`");
+    throw new Error(
+      "`useWeb3Client` must be used within a `<Web3ClientProvider>`"
+    );
   }
-  return chain ? ctx.getClient(chain) : { client: undefined, provider: undefined };
+  return chain
+    ? ctx.getClient(chain)
+    : { client: undefined, provider: undefined };
 }

--- a/packages/ui/src/hooks/use-arbitrum-balance.tsx
+++ b/packages/ui/src/hooks/use-arbitrum-balance.tsx
@@ -1,17 +1,18 @@
-import { useWeb3ClientContext } from "@/contexts/web3-client-context";
+import { useWeb3Client } from "@/contexts/web3-client-context";
+import { CustomChain } from "@/types";
 import { ethers } from "ethers";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
-export default function useArbitrumBalance() {
+export default function useBalance(chain: CustomChain) {
   const { address } = useAccount();
   const [balanceOnArbitrum, setBalanceOnArbitrum] = useState("");
-  const { childProvider } = useWeb3ClientContext();
+  const { provider } = useWeb3Client(chain);
 
   useEffect(() => {
     const getBalance = async () => {
-      if (address) {
-        const rawBalance = await childProvider.getBalance(address);
+      if (address && provider) {
+        const rawBalance = await provider.getBalance(address);
         const balance = ethers.utils.formatEther(rawBalance);
 
         setBalanceOnArbitrum(balance);
@@ -19,6 +20,6 @@ export default function useArbitrumBalance() {
     };
 
     getBalance();
-  }, [address]);
+  }, [address, provider]);
   return balanceOnArbitrum;
 }

--- a/packages/ui/src/routes/activity.index.tsx
+++ b/packages/ui/src/routes/activity.index.tsx
@@ -2,6 +2,7 @@ import HomeButton from "@/components/layout/home-button";
 import { TransactionStatusHeader } from "@/components/transaction/status-header";
 import { TransactionStatus } from "@/components/transaction/status-refactor";
 import { Transaction, TransactionsStorageService } from "@/lib/transactions";
+import { getArbitrumNetwork } from "@arbitrum/sdk";
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
@@ -42,6 +43,38 @@ function ActivityScreen() {
   const [loading, setLoading] = useState(false);
   const { address } = useAccount();
   const [txHistory, setTxHistory] = useState<Transaction[]>([]);
+  const [statuses, setStatuses] = useState<Record<string, boolean>>({});
+
+  // Ensures arbitrum netork exists on Arbitrum SDK
+  useEffect(() => {
+    let cancelled = false;
+
+    function checkWithRetry(txId: string, chainId: number, attempt = 1) {
+      try {
+        getArbitrumNetwork(chainId); // throws if not registered
+        if (!cancelled) {
+          setStatuses((s) => ({ ...s, [txId]: true }));
+        }
+      } catch (err) {
+        console.error(`Tx ${txId} attempt ${attempt} failed`, err);
+        if (!cancelled) {
+          if (attempt < 5)
+            setTimeout(() => checkWithRetry(txId, chainId, attempt + 1), 1000);
+        }
+      }
+    }
+
+    txHistory.forEach((tx) => {
+      setStatuses((s) => ({ ...s, [tx.bridgeHash]: false }));
+      if (tx.childChainId != null) {
+        checkWithRetry(tx.bridgeHash, tx.childChainId);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [txHistory]);
 
   useEffect(() => {
     if (address) {
@@ -69,7 +102,7 @@ function ActivityScreen() {
               >
                 <TransactionStatusHeader tx={x} />
                 <div className="collapse-content">
-                  <TransactionStatus tx={x} />
+                  {statuses[x.bridgeHash] && <TransactionStatus tx={x} />}
                 </div>
               </div>
             ))

--- a/packages/ui/src/routes/index.tsx
+++ b/packages/ui/src/routes/index.tsx
@@ -3,7 +3,7 @@ import WalletIcon from "@/assets/wallet.svg";
 import CustomConnectButton from "@/components/connect-wallet";
 import ErrorMessage from "@/components/error-message";
 import { useEthPrice } from "@/hooks/use-eth-price";
-import useArbitrumBalance from "@/hooks/use-arbitrum-balance";
+import useBalance from "@/hooks/use-arbitrum-balance";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import cn from "classnames";
@@ -27,12 +27,12 @@ interface FormError {
 function HomeScreen() {
   const navigate = useNavigate();
   const { address } = useAccount();
-  const arbBalance = useArbitrumBalance();
   const { openConnectModal } = useConnectModal();
   const [amountEth, setAmountEth] = useState<string>("");
   const [error, setError] = useState<FormError>();
   const { ethPrice } = useEthPrice();
   const { selectedChain, selectedParentChain } = useSelectedChain();
+  const balance = useBalance(selectedChain);
   function handleSubmit() {
     const amount = parseUnits(amountEth, 18);
     if (amount.lte("0")) {
@@ -40,7 +40,7 @@ function HomeScreen() {
       return;
     }
 
-    if (amount.gt(parseUnits(arbBalance, 18))) {
+    if (amount.gt(parseUnits(balance, 18))) {
       triggerError({ ...error, balance: true });
       return;
     }
@@ -108,7 +108,7 @@ function HomeScreen() {
                     { "text-red-600": error?.balance }
                   )}
                 >
-                  ETH
+                  {selectedChain.nativeCurrency.symbol}
                 </div>
                 <span
                   className={cn("text-neutral-500 duration-200 ease-in-out", {
@@ -116,7 +116,7 @@ function HomeScreen() {
                   })}
                   id="balance"
                 >
-                  Balance {arbBalance.slice(0, 10)}
+                  Balance {balance.slice(0, 10)}
                 </span>
               </div>
             </div>
@@ -124,7 +124,7 @@ function HomeScreen() {
               <button
                 type="button"
                 className="btn btn-neutral rounded-3xl px-5 font-normal"
-                onClick={() => setAmountEth(arbBalance)}
+                onClick={() => setAmountEth(balance)}
               >
                 Max
               </button>
@@ -168,10 +168,10 @@ function HomeScreen() {
             } else handleSubmit();
           }}
           type="submit"
-          disabled={!address || !arbBalance}
+          disabled={!address || !balance}
         >
           {address
-            ? arbBalance
+            ? balance
               ? "Continue"
               : "Loading balance..."
             : "Connect your wallet to withdraw"}

--- a/packages/ui/src/routes/withdraw.tsx
+++ b/packages/ui/src/routes/withdraw.tsx
@@ -1,6 +1,5 @@
 import { LEARN_MORE_URI } from "@/constants";
 import { useAlertContext } from "@/contexts/alert/alert-context";
-import { useWeb3ClientContext } from "@/contexts/web3-client-context";
 import { useEthPrice } from "@/hooks/use-eth-price";
 import useArbitrumBridge, { ClaimStatus } from "@/hooks/use-arbitrum-bridge";
 import {
@@ -19,6 +18,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Address } from "viem";
 import { useAccount } from "wagmi";
 import { useSelectedChain } from "@/hooks/use-selected-chain";
+import { useWeb3Client } from "@/contexts/web3-client-context";
 
 interface SearchParams {
   amount: string;
@@ -44,10 +44,11 @@ export const Route = createFileRoute("/withdraw")({
 function WithdrawScreen() {
   const navigate = useNavigate();
   const { address } = useAccount();
-  const { parentProvider, childProvider } = useWeb3ClientContext();
   const { amount: amountInWei } = Route.useSearch();
   const { ethPrice } = useEthPrice();
   const { selectedChain, selectedParentChain } = useSelectedChain();
+  const { provider: childProvider } = useWeb3Client(selectedChain);
+  const { provider: parentProvider } = useWeb3Client(selectedParentChain);
 
   const [approvedAproxFees, setApprovedAproxFees] = useState<boolean>(false);
   const [approvedSequencerMaySpeedUp, setApprovedSequencerMaySpeedUp] =
@@ -62,20 +63,23 @@ function WithdrawScreen() {
   const { setError } = useAlertContext();
   const { data: withdrawPrice, isFetching: withdrawPriceFetching } = useQuery({
     queryKey: ["withdrawPrice"],
-    queryFn: () => getMockedL2WithdrawPrice(childProvider),
+    queryFn: () => getMockedL2WithdrawPrice(childProvider!),
     refetchOnWindowFocus: true,
+    enabled: !!parentProvider,
     initialData: BigNumber.from(0),
   });
   const { data: confirmPrice, isFetching: confirmPriceFetching } = useQuery({
     queryKey: ["confirmPrice"],
-    queryFn: () => getMockedSendL1MsgPrice(parentProvider),
+    queryFn: () => getMockedSendL1MsgPrice(parentProvider!),
     refetchOnWindowFocus: true,
+    enabled: !!parentProvider,
     initialData: BigNumber.from(0),
   });
   const { data: claimPrice, isFetching: claimPriceFetching } = useQuery({
     queryKey: ["claimPrice"],
-    queryFn: () => getMockedL1ClaimTxGasLimit(parentProvider),
+    queryFn: () => getMockedL1ClaimTxGasLimit(parentProvider!),
     refetchOnWindowFocus: true,
+    enabled: !!parentProvider,
     initialData: BigNumber.from(0),
   });
 


### PR DESCRIPTION
## Tickets

[AFIV2-85](https://wakeuplabs.atlassian.net/browse/AFIV2-85)
[AFIV2-91](https://wakeuplabs.atlassian.net/browse/AFIV2-91)
[AFIV2-92](https://wakeuplabs.atlassian.net/browse/AFIV2-92)

## Description
Transaction status component was still using selectedChain hook, which is not related to the one the transaction must use.
This was making include tx check, claim status check and claim funds execution to fail.

## Solution
Re-signified the old useWeb3ClientContext.
Now it caches every chain - client/provider required by the transactions to fetch their data.
Also fixed wrong token symbol displayed on balance

[AFIV2-85]: https://wakeuplabs.atlassian.net/browse/AFIV2-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AFIV2-91]: https://wakeuplabs.atlassian.net/browse/AFIV2-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AFIV2-92]: https://wakeuplabs.atlassian.net/browse/AFIV2-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ