### PR TITLE
Fix/hide force when claimable

### DIFF
--- a/packages/ui/src/components/transaction/steps/force.tsx
+++ b/packages/ui/src/components/transaction/steps/force.tsx
@@ -94,7 +94,7 @@ export default function ForceStep({
         <ForceIncludeButton onForce={onForce} transaction={transaction} />
       ) : null}
 
-      {isWating24 && !isLoading ? (
+      {state !== TransactionState.CLAIMABLE && isWating24 && !isLoading ? (
         <>
           <a className="text-sm font-semibold">
             ~ {remainingHours} hours remaining

--- a/packages/ui/src/routes/withdraw.tsx
+++ b/packages/ui/src/routes/withdraw.tsx
@@ -135,7 +135,9 @@ function WithdrawScreen() {
       {/* amount */}
       <div className="flex items-center justify-between bg-neutral-50 border border-neutral-200 rounded-2xl md:p-6 p-4">
         <div className="flex items-center gap-3">
-          <img src={selectedChain.logoURI} alt={selectedChain.name} />
+          <div className="w-11 h-11">
+            <img src={selectedChain.logoURI} alt={selectedChain.name} />
+          </div>
           <div className="flex items-end space-x-2">
             <div
               data-test-id="withdraw-amount"


### PR DESCRIPTION
## Ticket
[AFIV2-109](https://wakeuplabs.atlassian.net/browse/AFIV2-109)
[AFIV2-94](https://wakeuplabs.atlassian.net/browse/AFIV2-94)
## Description
- Force transaction coundtown was still being shown if the transaction was claimable
- Chain icon was lacking a limited size, which would break ui if chain image was too big
## Solution
- Hide countdown if transaction is claimable
- Wrap img with a div and a defined size

[AFIV2-109]: https://wakeuplabs.atlassian.net/browse/AFIV2-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AFIV2-94]: https://wakeuplabs.atlassian.net/browse/AFIV2-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ